### PR TITLE
FIX: Guard against XSS in CapturedFormSubmission

### DIFF
--- a/code/CapturedFormSubmission.php
+++ b/code/CapturedFormSubmission.php
@@ -88,7 +88,7 @@ class CapturedFormSubmission extends DataObject implements PermissionProvider
 
 			if(!$field->Value) continue;
 
-			$htmlEnt = '<strong>'. $field->Title .'</strong>: '. $field->Value;
+			$htmlEnt = '<strong>'. $field->Title .'</strong>: '. $field->dbObject('Value')->XML();
 			array_push($toAdd, $htmlEnt);
 
 		}


### PR DESCRIPTION
As `Details()` returns `HTMLText` (which doesn’t do any escaping of HTML) the submitted values need to be escaped manually here